### PR TITLE
List shared links for a file-path

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -93,7 +93,7 @@ class Client
     /**
      * List shared links.
      *
-     * For empty path returns a list of all shared links. For non-empty path 
+     * For empty path returns a list of all shared links. For non-empty path
      * returns a list of all shared links with access to the given path.
      *
      * @link https://www.dropbox.com/developers/documentation/http/documentation#sharing-list_shared_links

--- a/src/Client.php
+++ b/src/Client.php
@@ -91,6 +91,25 @@ class Client
     }
 
     /**
+     * List shared links.
+     *
+     * For empty path returns a list of all shared links. For non-empty path 
+     * returns a list of all shared links with access to the given path.
+     *
+     * @link https://www.dropbox.com/developers/documentation/http/documentation#sharing-list_shared_links
+     */
+    public function listSharedLinks(string $path): array
+    {
+        $parameters = [
+            'path' => $this->normalizePath($path),
+        ];
+
+        $body = $this->rpcEndpointRequest('sharing/list_shared_links', $parameters);
+
+        return $body['links'];
+    }
+
+    /**
      * Delete the file or folder at a given path.
      *
      * If the path is a folder, all its contents will be deleted too.
@@ -322,25 +341,4 @@ class Client
         return $exception;
     }
 
-
-    /**
-     * List shared links of this user..
-     *
-     * If no path is given, returns a list of all shared links for the current user.
-     * If a non-empty path is given, returns a list of all shared links that allow access to the given path - direct links to the given 
-     * path and links to parent folders of the given path. Links to parent folders can be suppressed by setting direct_only to true. 
-     * The resolved visibility, though, may depend on other aspects such as team and shared folder settings).
-     *
-     * @link https://www.dropbox.com/developers/documentation/http/documentation#sharing-list_shared_links
-     */
-    public function listSharedLinks(string $path): array
-    {
-        $parameters = [
-            'path' => $this->normalizePath($path),
-        ];
-
-        $body = $this->rpcEndpointRequest('sharing/list_shared_links', $parameters);
-
-        return $body['links'];
-    }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -321,4 +321,26 @@ class Client
 
         return $exception;
     }
+
+
+    /**
+     * List shared links of this user..
+     *
+     * If no path is given, returns a list of all shared links for the current user.
+     * If a non-empty path is given, returns a list of all shared links that allow access to the given path - direct links to the given 
+     * path and links to parent folders of the given path. Links to parent folders can be suppressed by setting direct_only to true. 
+     * The resolved visibility, though, may depend on other aspects such as team and shared folder settings).
+     *
+     * @link https://www.dropbox.com/developers/documentation/http/documentation#sharing-list_shared_links
+     */
+    public function listSharedLinks(string $path): array
+    {
+        $parameters = [
+            'path' => $this->normalizePath($path),
+        ];
+
+        $body = $this->rpcEndpointRequest('sharing/list_shared_links', $parameters);
+
+        return $body['links'];
+    }
 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -342,7 +342,6 @@ class ClientTest extends TestCase
     /** @test */
     function it_can_list_shared_links()
     {
-        
         $mockGuzzle = $this->mock_guzzle_request(
             json_encode([
                 'name' => 'math',

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -339,6 +339,31 @@ class ClientTest extends TestCase
         $this->assertEquals(['name' => 'math'], $client->createSharedLinkWithSettings('Homework/math'));
     }
 
+    /** @test */
+    function it_can_list_shared_links()
+    {
+        
+        $mockGuzzle = $this->mock_guzzle_request(
+            json_encode([
+                'name' => 'math',
+                'links' => ['url' => 'https://dl.dropboxusercontent.com/apitl/1/YXNkZmFzZGcyMzQyMzI0NjU2NDU2NDU2'],
+            ]),
+            'https://api.dropboxapi.com/2/sharing/list_shared_links',
+            [
+                'json' => [
+                    'path' => '/Homework/math',
+                ],
+            ]
+        );
+
+        $client = new Client('test_token', $mockGuzzle);
+
+        $this->assertEquals(
+            ['url' => 'https://dl.dropboxusercontent.com/apitl/1/YXNkZmFzZGcyMzQyMzI0NjU2NDU2NDU2'],
+            $client->listSharedLinks('Homework/math')
+        );
+    }
+
     private function mock_guzzle_request($expectedResponse, $expectedEndpoint, $expectedParams)
     {
         $mockResponse = $this->getMockBuilder(ResponseInterface::class)

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -340,7 +340,7 @@ class ClientTest extends TestCase
     }
 
     /** @test */
-    function it_can_list_shared_links()
+    public function it_can_list_shared_links()
     {
         $mockGuzzle = $this->mock_guzzle_request(
             json_encode([


### PR DESCRIPTION
When calling create shared links with settings for a specific path which already has previously created shared link dropbox api will throw error. This method allows for check and retrieval of shared link if it is available.  