### PR TITLE
Use machine readable error code on BadRequest exception

### DIFF
--- a/src/Exceptions/BadRequest.php
+++ b/src/Exceptions/BadRequest.php
@@ -10,7 +10,7 @@ class BadRequest extends Exception
     /**
      * The dropbox error code supplied in the response.
      *
-     * @var string
+     * @var string|null
      */
     public $dropboxCode;
 

--- a/src/Exceptions/BadRequest.php
+++ b/src/Exceptions/BadRequest.php
@@ -8,35 +8,20 @@ use Psr\Http\Message\ResponseInterface;
 class BadRequest extends Exception
 {
     /**
-     * The dropbox error code supplied in the response
+     * The dropbox error code supplied in the response.
      *
      * @var string
      */
-    protected $dropboxCode = '';
+    public $dropboxCode;
 
     public function __construct(ResponseInterface $response)
     {
         $body = json_decode($response->getBody(), true);
 
-        if ($response->getStatusCode() === 409) {
-            $this->setDropboxCode($body['error']['.tag']);
+        if (isset($body['error']['.tag'])) {
+            $this->dropboxCode = $body['error']['.tag'];
         }
 
         parent::__construct($body['error_summary']);
-    }
-
-    protected function setDropboxCode(string $code)
-    {
-        $this->dropboxCode = $code;
-    }
-
-    /**
-     * Returns the machine readable dropbox error code
-     *
-     * @return string
-     */
-    public function getDropboxCode(): string
-    {
-        return $this->dropboxCode;
     }
 }

--- a/src/Exceptions/BadRequest.php
+++ b/src/Exceptions/BadRequest.php
@@ -7,10 +7,36 @@ use Psr\Http\Message\ResponseInterface;
 
 class BadRequest extends Exception
 {
+    /**
+     * The dropbox error code supplied in the response
+     *
+     * @var string
+     */
+    protected $dropboxCode = '';
+
     public function __construct(ResponseInterface $response)
     {
         $body = json_decode($response->getBody(), true);
 
+        if ($response->getStatusCode() === 409) {
+            $this->setDropboxCode($body['error']['.tag']);
+        }
+
         parent::__construct($body['error_summary']);
+    }
+
+    protected function setDropboxCode(string $code)
+    {
+        $this->dropboxCode = $code;
+    }
+
+    /**
+     * Returns the machine readable dropbox error code
+     *
+     * @return string
+     */
+    public function getDropboxCode(): string
+    {
+        return $this->dropboxCode;
     }
 }


### PR DESCRIPTION
Currently the `BadRequest` exception only uses the `error_summary` for the exception message, which is all well and fine, but dropbox discourages this being used as a machine readable way to identify problems.

> A string that summarizes the value of the "error" key. It is a concatenation of the hierarchy of union tags that make up the error. While this provides a human-readable error string, "error_summary" should not be used for programmatic error handling. To disincentive this, we append a random number of "." characters at the end of the string.

Our use case for this is catching errors such as `insufficient_quota` and emailing a warning to the user, which currently can't be done using your flysystem adapter.