### PR TITLE
Implement revokeToken and getAccountInfo methods

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -285,7 +285,7 @@ class Client
     }
 
     /**
-     * Get Account Info for current authenticated user
+     * Get Account Info for current authenticated user.
      *
      * @link https://www.dropbox.com/developers/documentation/http/documentation#users-get_current_account
      *
@@ -297,7 +297,7 @@ class Client
     }
 
     /**
-     * Revoke current access token
+     * Revoke current access token.
      *
      * @link https://www.dropbox.com/developers/documentation/http/documentation#auth-token-revoke
      *

--- a/src/Client.php
+++ b/src/Client.php
@@ -296,6 +296,18 @@ class Client
         return $this->rpcEndpointRequest('users/get_current_account', []);
     }
 
+    /**
+     * Revoke current access token
+     *
+     * @link https://www.dropbox.com/developers/documentation/http/documentation#auth-token-revoke
+     *
+     * @return array
+     */
+    public function revokeToken(): array
+    {
+        return $this->rpcEndpointRequest('auth/token/revoke', []);
+    }
+
     protected function normalizePath(string $path): string
     {
         $path = trim($path, '/');

--- a/src/Client.php
+++ b/src/Client.php
@@ -284,6 +284,18 @@ class Client
         return $metadata;
     }
 
+    /**
+     * Get Account Info for current authenticated user
+     *
+     * @link https://www.dropbox.com/developers/documentation/http/documentation#users-get_current_account
+     *
+     * @return array
+     */
+    public function getAccountInfo(): array
+    {
+        return $this->rpcEndpointRequest('users/get_current_account', []);
+    }
+
     protected function normalizePath(string $path): string
     {
         $path = trim($path, '/');

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -307,6 +307,23 @@ class ClientTest extends TestCase
     }
 
     /** @test */
+    public function it_can_revoke_token()
+    {
+
+        $mockGuzzle = $this->mock_guzzle_request(
+            json_encode([]),
+            'https://api.dropboxapi.com/2/auth/token/revoke',
+            [
+                'json' => []
+            ]
+        );
+
+        $client = new Client('test_token', $mockGuzzle);
+
+        $this->assertEquals([], $client->revokeToken());
+    }
+
+    /** @test */
     public function content_endpoint_request_can_throw_exception()
     {
         $mockGuzzle = $this->getMockBuilder(GuzzleClient::class)

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -269,6 +269,44 @@ class ClientTest extends TestCase
     }
 
     /** @test */
+    public function it_can_get_account_info()
+    {
+        $expectedResponse = [
+            "account_id" => "dbid:AAH4f99T0taONIb-OurWxbNQ6ywGRopQngc",
+            "name" => [
+                "given_name" => "Franz",
+                "surname" => "Ferdinand",
+                "familiar_name" => "Franz",
+                "display_name" => "Franz Ferdinand (Personal)",
+                "abbreviated_name" => "FF"
+            ],
+            "email" => "franz@gmail.com",
+            "email_verified" => false,
+            "disabled" => false,
+            "locale" => "en",
+            "referral_link" => "https://db.tt/ZITNuhtI",
+            "is_paired" => false,
+            "account_type" => [
+                ".tag" => "basic"
+            ],
+            "profile_photo_url" => "https://dl-web.dropbox.com/account_photo/get/dbid%3AAAH4f99T0taONIb-OurWxbNQ6ywGRopQngc?vers=1453416673259&size=128x128",
+            "country" => "US"
+        ];
+
+        $mockGuzzle = $this->mock_guzzle_request(
+            json_encode($expectedResponse),
+            'https://api.dropboxapi.com/2/users/get_current_account',
+            [
+                'json' => []
+            ]
+        );
+
+        $client = new Client('test_token', $mockGuzzle);
+
+        $this->assertEquals($expectedResponse, $client->getAccountInfo());
+    }
+
+    /** @test */
     public function content_endpoint_request_can_throw_exception()
     {
         $mockGuzzle = $this->getMockBuilder(GuzzleClient::class)

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -309,7 +309,6 @@ class ClientTest extends TestCase
     /** @test */
     public function it_can_revoke_token()
     {
-
         $mockGuzzle = $this->mock_guzzle_request(
             json_encode([]),
             'https://api.dropboxapi.com/2/auth/token/revoke',

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -272,32 +272,32 @@ class ClientTest extends TestCase
     public function it_can_get_account_info()
     {
         $expectedResponse = [
-            "account_id" => "dbid:AAH4f99T0taONIb-OurWxbNQ6ywGRopQngc",
-            "name" => [
-                "given_name" => "Franz",
-                "surname" => "Ferdinand",
-                "familiar_name" => "Franz",
-                "display_name" => "Franz Ferdinand (Personal)",
-                "abbreviated_name" => "FF"
+            'account_id' => 'dbid:AAH4f99T0taONIb-OurWxbNQ6ywGRopQngc',
+            'name' => [
+                'given_name' => 'Franz',
+                'surname' => 'Ferdinand',
+                'familiar_name' => 'Franz',
+                'display_name' => 'Franz Ferdinand (Personal)',
+                'abbreviated_name' => 'FF',
             ],
-            "email" => "franz@gmail.com",
-            "email_verified" => false,
-            "disabled" => false,
-            "locale" => "en",
-            "referral_link" => "https://db.tt/ZITNuhtI",
-            "is_paired" => false,
-            "account_type" => [
-                ".tag" => "basic"
+            'email' => 'franz@gmail.com',
+            'email_verified' => false,
+            'disabled' => false,
+            'locale' => 'en',
+            'referral_link' => 'https://db.tt/ZITNuhtI',
+            'is_paired' => false,
+            'account_type' => [
+                '.tag' => 'basic',
             ],
-            "profile_photo_url" => "https://dl-web.dropbox.com/account_photo/get/dbid%3AAAH4f99T0taONIb-OurWxbNQ6ywGRopQngc?vers=1453416673259&size=128x128",
-            "country" => "US"
+            'profile_photo_url' => 'https://dl-web.dropbox.com/account_photo/get/dbid%3AAAH4f99T0taONIb-OurWxbNQ6ywGRopQngc?vers=1453416673259&size=128x128',
+            'country' => 'US',
         ];
 
         $mockGuzzle = $this->mock_guzzle_request(
             json_encode($expectedResponse),
             'https://api.dropboxapi.com/2/users/get_current_account',
             [
-                'json' => []
+                'json' => [],
             ]
         );
 
@@ -314,7 +314,7 @@ class ClientTest extends TestCase
             json_encode([]),
             'https://api.dropboxapi.com/2/auth/token/revoke',
             [
-                'json' => []
+                'json' => [],
             ]
         );
 


### PR DESCRIPTION
I was migrating an application that uses the old phpleague package for dropbox integration, and found that this is missing this two API methods that I need.

I would appreciate if you can merge it so I can use your package instead of extending the Client on my application.

The failing test isn't mine, looks the original master branch was already failing.