### PR TITLE
Fix broken revokeToken and getAccountInfo

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -293,7 +293,7 @@ class Client
      */
     public function getAccountInfo(): array
     {
-        return $this->rpcEndpointRequest('users/get_current_account', []);
+        return $this->rpcEndpointRequest('users/get_current_account');
     }
 
     /**
@@ -301,11 +301,11 @@ class Client
      *
      * @link https://www.dropbox.com/developers/documentation/http/documentation#auth-token-revoke
      *
-     * @return array
+     * @return void
      */
-    public function revokeToken(): array
+    public function revokeToken()
     {
-        return $this->rpcEndpointRequest('auth/token/revoke', []);
+        $this->rpcEndpointRequest('auth/token/revoke');
     }
 
     protected function normalizePath(string $path): string
@@ -344,12 +344,16 @@ class Client
         return $response;
     }
 
-    public function rpcEndpointRequest(string $endpoint, array $parameters): array
+    public function rpcEndpointRequest(string $endpoint, array $parameters = null)
     {
         try {
-            $response = $this->client->post("https://api.dropboxapi.com/2/{$endpoint}", [
-                'json' => $parameters,
-            ]);
+            $options = [];
+
+            if ($parameters) {
+                $options['json'] = $parameters;
+            }
+
+            $response = $this->client->post("https://api.dropboxapi.com/2/{$endpoint}", $options);
         } catch (ClientException $exception) {
             throw $this->determineException($exception);
         }

--- a/src/Client.php
+++ b/src/Client.php
@@ -344,7 +344,7 @@ class Client
         return $response;
     }
 
-    public function rpcEndpointRequest(string $endpoint, array $parameters = null)
+    public function rpcEndpointRequest(string $endpoint, array $parameters = null): array
     {
         try {
             $options = [];
@@ -358,7 +358,13 @@ class Client
             throw $this->determineException($exception);
         }
 
-        return json_decode($response->getBody(), true);
+        $response = json_decode($response->getBody(), true);
+
+        if (is_null($response)) {
+            $response = [];
+        }
+
+        return $response;
     }
 
     protected function determineException(ClientException $exception): Exception

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -296,9 +296,7 @@ class ClientTest extends TestCase
         $mockGuzzle = $this->mock_guzzle_request(
             json_encode($expectedResponse),
             'https://api.dropboxapi.com/2/users/get_current_account',
-            [
-                'json' => [],
-            ]
+            []
         );
 
         $client = new Client('test_token', $mockGuzzle);
@@ -310,16 +308,14 @@ class ClientTest extends TestCase
     public function it_can_revoke_token()
     {
         $mockGuzzle = $this->mock_guzzle_request(
-            json_encode([]),
+            null,
             'https://api.dropboxapi.com/2/auth/token/revoke',
-            [
-                'json' => [],
-            ]
+            []
         );
 
         $client = new Client('test_token', $mockGuzzle);
 
-        $this->assertEquals([], $client->revokeToken());
+        $client->revokeToken();
     }
 
     /** @test */
@@ -462,9 +458,12 @@ class ClientTest extends TestCase
     {
         $mockResponse = $this->getMockBuilder(ResponseInterface::class)
                              ->getMock();
-        $mockResponse->expects($this->once())
-                     ->method('getBody')
-                     ->willReturn($expectedResponse);
+
+        if ($expectedResponse) {
+            $mockResponse->expects($this->once())
+                ->method('getBody')
+                ->willReturn($expectedResponse);
+        }
 
         $mockGuzzle = $this->getMockBuilder(GuzzleClient::class)
                            ->setMethods(['post'])


### PR DESCRIPTION
The request was failing on revokeToken and getAccountInfo since they doesn't send any parameters, and a empty array `[]` is invalid for dropbox api.

Also revokeToken doesn't return anything, so rpcEndpointRequest is invalid for this use. I've created an `voidEndpointRequest` for requests that doesn't return anything.

The version's 1.5.0 methods that I implement are broken, so I'm proposing this patch to fix the issue.