### PR TITLE
Upload session

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -296,7 +296,7 @@ class Client
     }
 
     /**
-     * Check if the contents is a pipe stream (not seekable, no size defined)
+     * Check if the contents is a pipe stream (not seekable, no size defined).
      *
      * @param string|resource $contents
      *

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client
     const THUMBNAIL_SIZE_L = 'w640h480';
     const THUMBNAIL_SIZE_XL = 'w1024h768';
 
-    const MAX_CHUNK_SIZE = 157286400;
+    const MAX_CHUNK_SIZE = 150 * 1024 * 1024;
 
     /** @var string */
     protected $accessToken;

--- a/src/Client.php
+++ b/src/Client.php
@@ -284,11 +284,27 @@ class Client
     {
         $size = is_string($contents) ? strlen($contents) : fstat($contents)['size'];
 
-        // @todo: remove this when/if guzzle/psr7#79 or guzzle/psr7#155 be fixed
-        // it's a workaround to avoid pipes being sent with zero size by guzzle/http
-        $isPipe = is_resource($contents) ? (fstat($contents)['mode'] & 010000) != 0 : false;
+        if ($this->isPipe($contents)) {
+            return true;
+        }
 
-        return $isPipe || $size === null || $size > $this->getMaxChunkSize();
+        if ($size === null) {
+            return true;
+        }
+
+        return $size > $this->getMaxChunkSize();
+    }
+
+    /**
+     * Check if the contents is a pipe stream (not seekable, no size defined)
+     *
+     * @param string|resource $contents
+     *
+     * @return bool
+     */
+    protected function isPipe($contents): bool
+    {
+        return is_resource($contents) ? (fstat($contents)['mode'] & 010000) != 0 : false;
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -284,7 +284,11 @@ class Client
     {
         $size = is_string($contents) ? strlen($contents) : fstat($contents)['size'];
 
-        return $size === null || $size > $this->getMaxChunkSize();
+        // @todo: remove this when/if guzzle/psr7#79 or guzzle/psr7#155 be fixed
+        // it's a workaround to avoid pipes being sent with zero size by guzzle/http
+        $isPipe = is_resource($contents) ? (fstat($contents)['mode'] & 010000) != 0 : false;
+
+        return $isPipe || $size === null || $size > $this->getMaxChunkSize();
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -405,7 +405,11 @@ class Client
         $arguments = compact('cursor');
         $arguments['commit'] = compact('path', 'mode', 'autorename', 'mute');
 
-        $response = $this->contentEndpointRequest('files/upload_session/finish', $arguments, $contents);
+        $response = $this->contentEndpointRequest(
+            'files/upload_session/finish',
+            $arguments,
+            ($contents == '') ? null : $contents
+        );
 
         return json_decode($response->getBody(), true);
     }

--- a/src/UploadSessionCursor.php
+++ b/src/UploadSessionCursor.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: esoares
+ * Date: 18/07/17
+ * Time: 16:32
+ */
+
+namespace Spatie\Dropbox;
+
+class UploadSessionCursor
+{
+    /**
+     * The upload session ID (returned by upload_session/start).
+     *
+     * @var string
+     */
+    public $session_id;
+
+    /**
+     * The amount of data that has been uploaded so far. We use this to make sure upload data isn't lost or duplicated in the event of a network error.
+     *
+     * @var integer
+     */
+    public $offset;
+
+    /**
+     * UploadSessionCursor constructor.
+     *
+     * @param string $session_id
+     * @param int $offset
+     */
+    public function __construct(string $session_id, int $offset = 0)
+    {
+        $this->session_id = $session_id;
+        $this->offset = $offset;
+    }
+}

--- a/src/UploadSessionCursor.php
+++ b/src/UploadSessionCursor.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: esoares
- * Date: 18/07/17
- * Time: 16:32
- */
 
 namespace Spatie\Dropbox;
 
@@ -20,7 +14,7 @@ class UploadSessionCursor
     /**
      * The amount of data that has been uploaded so far. We use this to make sure upload data isn't lost or duplicated in the event of a network error.
      *
-     * @var integer
+     * @var int
      */
     public $offset;
 
@@ -28,7 +22,7 @@ class UploadSessionCursor
      * UploadSessionCursor constructor.
      *
      * @param string $session_id
-     * @param int $offset
+     * @param int    $offset
      */
     public function __construct(string $session_id, int $offset = 0)
     {

--- a/src/UploadSessionCursor.php
+++ b/src/UploadSessionCursor.php
@@ -18,12 +18,6 @@ class UploadSessionCursor
      */
     public $offset;
 
-    /**
-     * UploadSessionCursor constructor.
-     *
-     * @param string $session_id
-     * @param int    $offset
-     */
     public function __construct(string $session_id, int $offset = 0)
     {
         $this->session_id = $session_id;

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -8,9 +8,9 @@ use Psr\Http\Message\StreamInterface;
 use GuzzleHttp\Client as GuzzleClient;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Spatie\Dropbox\UploadSessionCursor;
 use GuzzleHttp\Exception\ClientException;
 use Spatie\Dropbox\Exceptions\BadRequest;
-use Spatie\Dropbox\UploadSessionCursor;
 
 class ClientTest extends TestCase
 {
@@ -309,9 +309,9 @@ class ClientTest extends TestCase
                         [
                             'cursor' => [
                                 'session_id' => 'mockedUploadSessionId',
-                                'offset' => 10
+                                'offset' => 10,
                             ],
-                            'close' => false
+                            'close' => false,
                         ]
                     ),
                     'Content-Type'    => 'application/octet-stream',
@@ -380,7 +380,7 @@ class ClientTest extends TestCase
     {
         $mockGuzzle = $this->mock_guzzle_request(
             json_encode([
-                'name' => 'answers.txt'
+                'name' => 'answers.txt',
             ]),
             'https://content.dropboxapi.com/2/files/upload_session/finish',
             [
@@ -389,14 +389,14 @@ class ClientTest extends TestCase
                         [
                             'cursor' => [
                                 'session_id' => 'mockedUploadSessionId',
-                                'offset' => 10
+                                'offset' => 10,
                             ],
                             'commit' => [
                                 'path' => 'Homework/math/answers.txt',
                                 'mode' => 'add',
                                 'autorename' => false,
                                 'mute' => false,
-                            ]
+                            ],
                         ]
                     ),
                     'Content-Type'    => 'application/octet-stream',
@@ -416,7 +416,7 @@ class ClientTest extends TestCase
         );
 
         $this->assertEquals([
-            'name' => 'answers.txt'
+            'name' => 'answers.txt',
         ], $response);
     }
 
@@ -656,7 +656,7 @@ class ClientTest extends TestCase
             $withs = [];
             $returns = [];
 
-            foreach($chunks as $chunk) {
+            foreach ($chunks as $chunk) {
                 $offset += $chunkSize;
                 $withs[] = [$chunk, $this->anything()];
                 $returns[] = new UploadSessionCursor('mockedSessionId', $offset);

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -339,7 +339,7 @@ class ClientTest extends TestCase
 
         $this->assertEquals(
             ['name' => 'answers.txt'],
-            $mockClient->uploadChunked('Homework/math/answers.txt', $content, 6)
+            $mockClient->uploadChunked('Homework/math/answers.txt', $content, 'add', 6)
         );
     }
 
@@ -355,7 +355,7 @@ class ClientTest extends TestCase
 
         $this->assertEquals(
             ['name' => 'answers.txt'],
-            $mockClient->uploadChunked('Homework/math/answers.txt', $resource, 6)
+            $mockClient->uploadChunked('Homework/math/answers.txt', $resource, 'add', 6)
         );
     }
 
@@ -371,7 +371,7 @@ class ClientTest extends TestCase
 
         $this->assertEquals(
             ['name' => 'answers.txt'],
-            $mockClient->uploadChunked('Homework/math/answers.txt', $resource, 21)
+            $mockClient->uploadChunked('Homework/math/answers.txt', $resource, 'add', 21)
         );
     }
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -332,6 +332,21 @@ class ClientTest extends TestCase
     }
 
     /** @test */
+    public function it_automatically_chunk_uploads()
+    {
+        $content = 'chunk0chunk1chunk2rest';
+        $mockClient = $this->mock_chunked_upload_client($content, 6);
+        $mockClient->expects($this->any())
+            ->method('getMaxChunkSize')
+            ->willReturn('6');
+
+        $this->assertEquals(
+            ['name' => 'answers.txt'],
+            $mockClient->upload('Homework/math/answers.txt', $content, 'add')
+        );
+    }
+
+    /** @test */
     public function it_can_upload_a_file_string_chunked()
     {
         $content = 'chunk0chunk1chunk2rest';
@@ -636,7 +651,7 @@ class ClientTest extends TestCase
 
         $mockClient = $this->getMockBuilder(Client::class)
             ->setConstructorArgs(['test_token'])
-            ->setMethodsExcept(['uploadChunked'])
+            ->setMethodsExcept(['uploadChunked', 'upload'])
             ->getMock();
 
         $mockClient->expects($this->once())


### PR DESCRIPTION
This PR proposes a fix (actually a feature) to #10.

Since Dropbox API supports uploads up to 150MB in a single request, we should break it into many chunks and use the `upload_session` api feature.

This PR implement the following public methods to the Client:

- uploadSessionStart
- uploadSessionAppend
- uploadSessionFinish
- uploadChunked

The last one is the main method that should be used outside the client, but I made the other methods public if someone want to do it own implementation (someone may need split the uploads in many processes to speedup or distribute load).

**Please don't merge this pull request until I check this points:**

- [x] Add PHPDOC to new methods
- [x] Test on my local environment for large files upload