### PR TITLE
Update from move to move_v2

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -248,7 +248,7 @@ class Client
      *
      * If the source path is a folder all its contents will be moved.
      *
-     * @link https://www.dropbox.com/developers/documentation/http/documentation#files-move
+     * @link https://www.dropbox.com/developers/documentation/http/documentation#files-move_v2
      */
     public function move(string $fromPath, string $toPath): array
     {
@@ -257,7 +257,7 @@ class Client
             'to_path' => $this->normalizePath($toPath),
         ];
 
-        return $this->rpcEndpointRequest('files/move', $parameters);
+        return $this->rpcEndpointRequest('files/move_v2', $parameters);
     }
 
     /**

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -226,7 +226,7 @@ class ClientTest extends TestCase
 
         $mockGuzzle = $this->mock_guzzle_request(
             json_encode($expectedResponse),
-            'https://api.dropboxapi.com/2/files/move',
+            'https://api.dropboxapi.com/2/files/move_v2',
             [
                 'json' => [
                     'from_path' => '/from/path/file.txt',


### PR DESCRIPTION
Seems `move` is deprecated, so I suggest to upgrade to move_v2 as documentation says here:

https://www.dropbox.com/developers/documentation/http/documentation#files-move