### PR TITLE
Fix missing `.tag` from uploadSessionFinish response

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -448,7 +448,11 @@ class Client
             ($contents == '') ? null : $contents
         );
 
-        return json_decode($response->getBody(), true);
+        $metadata = json_decode($response->getBody(), true);
+
+        $metadata['.tag'] = 'file';
+
+        return $metadata;
     }
 
     /**

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -412,6 +412,7 @@ class ClientTest extends TestCase
         );
 
         $this->assertEquals([
+            '.tag' => 'file',
             'name' => 'answers.txt',
         ], $response);
     }


### PR DESCRIPTION
This fixes the bug related by @chris-faulkner on PR #21 