### PR TITLE
Fixed large file / chunked upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@ This is a minimal PHP implementation of the [Dropbox API v2](https://www.dropbox
 Here are a few examples on how you can use the package:
 
 ```php
+/**
+ * @param string            $accessToken
+ * @param GuzzleClient|null $client
+ * @param int               $maxChunkSize Set max chunk size per request (determines when to switch from "one shot upload" to upload session and defines chunk size for uploads via session).
+ * @param int               $maxUploadChunkRetries How many times to retry an upload session start/append after RequestException.
+ */
+// Spatie\Dropbox\Client(string $accessToken, GuzzleClient $client = null, int $maxChunkSize = self::MAX_CHUNK_SIZE, int $maxUploadChunkRetries = 0)
+
+//create a simple client
 $client = new Spatie\Dropbox\Client($authorizationToken);
 
 //create a folder
@@ -21,6 +30,11 @@ $client->listFolder($path);
 
 //get a temporary link
 $client->getTemporaryLink($path);
+
+//...//
+
+// If you want to compensate for network issues during chunked upload then you can create a client like this:
+$client = new Spatie\Dropbox\Client($authorizationToken, null, 4*1024*1024, 1); // any upload larger than specified $maxChunkSize (4MB) will be split into chunks of $maxChunkSize and each chunk append may be retried $maxUploadChunkRetries (1).
 ```
 ## Installation
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -32,7 +32,7 @@ class ClientTest extends TestCase
 
         $mockGuzzle = $this->mock_guzzle_request(
             json_encode($expectedResponse),
-            'https://api.dropboxapi.com/2/files/copy',
+            'https://api.dropboxapi.com/2/files/copy_v2',
             [
                 'json' => [
                     'from_path' => '/from/path/file.txt',
@@ -643,7 +643,7 @@ class ClientTest extends TestCase
 
         $mockClient->expects($this->once())
             ->method('uploadSessionFinish')
-            ->with(array_pop($chunks), $this->anything(), 'Homework/math/answers.txt', 'add')
+            ->with('', $this->anything(), 'Homework/math/answers.txt', 'add')
             ->willReturn(['name' => 'answers.txt']);
 
         $remainingChunks = count($chunks);


### PR DESCRIPTION
1. Fixed chunked upload.  It now uses stream chaining instead of memory stream (which could exhaust system memory easily) and supports virtually any file size.

2. I changed copy endpoint from deprecated "copy" to "copy_v2". This could be a breaking change for some because result is now wrapped into .metadata key (the same as move_v2 and others).

3. I added settable max chunk size (hard limited by Dropbox max chunk size) in case we want smaller chunks. This can be further improved with adding chunk append retry on exception (bad connectivity, timeouts etc.).