### PR TITLE
Adjust normalizePath to allow id/rev/ns to be queried 

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -528,6 +528,11 @@ class Client
 
     protected function normalizePath(string $path): string
     {
+        if (preg_match("/^id:.*|^(ns:[0-9]+(\/.*)?)/",  $path) === 1)
+        {
+            return $path;
+        }
+        
         $path = trim($path, '/');
 
         return ($path === '') ? '' : '/'.$path;

--- a/src/Client.php
+++ b/src/Client.php
@@ -528,7 +528,7 @@ class Client
 
     protected function normalizePath(string $path): string
     {
-        if (preg_match("/^id:.*|^(ns:[0-9]+(\/.*)?)/",  $path) === 1)
+        if (preg_match("/^id:.*|^rev:.*|^(ns:[0-9]+(\/.*)?)/",  $path) === 1)
         {
             return $path;
         }


### PR DESCRIPTION
Slight change to normalizePath function to check to see if the path starts with id:/rev:/ns: and return it back accordingly without the '/' prefix.
