### PR TITLE
Fix for piped streams

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -373,16 +373,17 @@ class Client
 
         if ($this->isPipe($contents)) {
             /** @var resource $contents */
-            $stream = new \GuzzleHttp\Psr7\PumpStream(function($length) use($contents) {
+            $stream = new \GuzzleHttp\Psr7\PumpStream(function ($length) use ($contents) {
                 $data = fread($contents, $length);
-                if(strlen($data) === 0)
+                if (strlen($data) === 0) {
                     return false;
+                }
+
                 return $data;
             });
         } else {
             $stream = Psr7\stream_for($contents);
         }
-
 
         $cursor = $this->uploadChunk(self::UPLOAD_SESSION_START, $stream, $chunkSize, null);
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -371,8 +371,20 @@ class Client
             $chunkSize = $this->maxChunkSize;
         }
 
-        $stream = Psr7\stream_for($contents);
+        if ($this->isPipe($contents)) {
+            /** @var resource $contents */
+            $stream = new \GuzzleHttp\Psr7\PumpStream(function($length) use($contents) {
+                $data = fread($contents, $length);
+                if(strlen($data) === 0)
+                    return false;
+                return $data;
+            });
+        } else {
+            $stream = Psr7\stream_for($contents);
+        }
+
         $cursor = $this->uploadChunk(self::UPLOAD_SESSION_START, $stream, $chunkSize, null);
+
         while (! $stream->eof()) {
             $cursor = $this->uploadChunk(self::UPLOAD_SESSION_APPEND, $stream, $chunkSize, $cursor);
         }


### PR DESCRIPTION
Hi,

this patch is a fix for piped streams on Linux (I found no issue on Windows using the old code).
It wraps pipes using a stream pump with minimal buffer.
Ref issue: https://github.com/spatie/dropbox-api/issues/37

Best regards