### PR TITLE
Add getter and setter for the access token

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -51,11 +51,7 @@ class Client
     {
         $this->accessToken = $accessToken;
 
-        $this->client = $client ?? new GuzzleClient([
-                'headers' => [
-                    'Authorization' => "Bearer {$this->accessToken}",
-                ],
-            ]);
+        $this->client = $client ?? new GuzzleClient();
 
         $this->maxChunkSize = ($maxChunkSize < self::MAX_CHUNK_SIZE ? ($maxChunkSize > 1 ? $maxChunkSize : 1) : self::MAX_CHUNK_SIZE);
         $this->maxUploadChunkRetries = $maxUploadChunkRetries;
@@ -557,7 +553,7 @@ class Client
 
         try {
             $response = $this->client->post("https://content.dropboxapi.com/2/{$endpoint}", [
-                'headers' => $headers,
+                'headers' => $this->getHeaders($headers),
                 'body' => $body,
             ]);
         } catch (ClientException $exception) {
@@ -570,7 +566,7 @@ class Client
     public function rpcEndpointRequest(string $endpoint, array $parameters = null): array
     {
         try {
-            $options = [];
+            $options = ['headers' => $this->getHeaders()];
 
             if ($parameters) {
                 $options['json'] = $parameters;
@@ -615,5 +611,33 @@ class Client
         }
 
         return Psr7\stream_for($contents);
+    }
+
+    /**
+     * Get the access token.
+     */
+    public function getAccessToken(): string
+    {
+        return $this->accessToken;
+    }
+
+    /**
+     * Set the access token.
+     */
+    public function setAccessToken(string $accessToken): self
+    {
+        $this->accessToken = $accessToken;
+
+        return $this;
+    }
+
+    /**
+     * Get the HTTP headers.
+     */
+    protected function getHeaders(array $headers = []): array
+    {
+        return array_merge([
+            'Authorization' => "Bearer {$this->accessToken}",
+        ], $headers);
     }
 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -34,6 +34,9 @@ class ClientTest extends TestCase
             json_encode($expectedResponse),
             'https://api.dropboxapi.com/2/files/copy_v2',
             [
+                'headers' => [
+                    'Authorization' => 'Bearer test_token',
+                ],
                 'json' => [
                     'from_path' => '/from/path/file.txt',
                     'to_path' => '/to/path/file.txt',
@@ -53,6 +56,9 @@ class ClientTest extends TestCase
             json_encode(['name' => 'math']),
             'https://api.dropboxapi.com/2/files/create_folder',
             [
+                'headers' => [
+                    'Authorization' => 'Bearer test_token',
+                ],
                 'json' => [
                     'path' => '/Homework/math',
                 ],
@@ -71,6 +77,9 @@ class ClientTest extends TestCase
             json_encode(['name' => 'math']),
             'https://api.dropboxapi.com/2/files/delete',
             [
+                'headers' => [
+                    'Authorization' => 'Bearer test_token',
+                ],
                 'json' => [
                     'path' => '/Homework/math',
                 ],
@@ -96,6 +105,7 @@ class ClientTest extends TestCase
             'https://content.dropboxapi.com/2/files/download',
             [
                 'headers' => [
+                    'Authorization' => 'Bearer test_token',
                     'Dropbox-API-Arg' => json_encode(['path' => '/Homework/math/answers.txt']),
                 ],
                 'body' => '',
@@ -114,6 +124,9 @@ class ClientTest extends TestCase
             json_encode(['name' => 'math']),
             'https://api.dropboxapi.com/2/files/get_metadata',
             [
+                'headers' => [
+                    'Authorization' => 'Bearer test_token',
+                ],
                 'json' => [
                     'path' => '/Homework/math',
                 ],
@@ -135,6 +148,9 @@ class ClientTest extends TestCase
             ]),
             'https://api.dropboxapi.com/2/files/get_temporary_link',
             [
+                'headers' => [
+                    'Authorization' => 'Bearer test_token',
+                ],
                 'json' => [
                     'path' => '/Homework/math',
                 ],
@@ -160,6 +176,7 @@ class ClientTest extends TestCase
             'https://content.dropboxapi.com/2/files/get_thumbnail',
             [
                 'headers' => [
+                    'Authorization' => 'Bearer test_token',
                     'Dropbox-API-Arg' => json_encode(
                         [
                             'path' => '/Homework/math/answers.jpg',
@@ -184,6 +201,9 @@ class ClientTest extends TestCase
             json_encode(['name' => 'math']),
             'https://api.dropboxapi.com/2/files/list_folder',
             [
+                'headers' => [
+                    'Authorization' => 'Bearer test_token',
+                ],
                 'json' => [
                     'path' => '/Homework/math',
                     'recursive' => true,
@@ -203,6 +223,9 @@ class ClientTest extends TestCase
             json_encode(['name' => 'math']),
             'https://api.dropboxapi.com/2/files/list_folder/continue',
             [
+                'headers' => [
+                    'Authorization' => 'Bearer test_token',
+                ],
                 'json' => [
                     'cursor' => 'ZtkX9_EHj3x7PMkVuFIhwKYXEpwpLwyxp9vMKomUhllil9q7eWiAu',
                 ],
@@ -229,6 +252,9 @@ class ClientTest extends TestCase
             json_encode($expectedResponse),
             'https://api.dropboxapi.com/2/files/move_v2',
             [
+                'headers' => [
+                    'Authorization' => 'Bearer test_token',
+                ],
                 'json' => [
                     'from_path' => '/from/path/file.txt',
                     'to_path' => '',
@@ -249,6 +275,7 @@ class ClientTest extends TestCase
             'https://content.dropboxapi.com/2/files/upload',
             [
                 'headers' => [
+                    'Authorization' => 'Bearer test_token',
                     'Dropbox-API-Arg' => json_encode([
                         'path' => '/Homework/math/answers.txt',
                         'mode' => 'add',
@@ -275,6 +302,7 @@ class ClientTest extends TestCase
             'https://content.dropboxapi.com/2/files/upload_session/start',
             [
                 'headers' => [
+                    'Authorization' => 'Bearer test_token',
                     'Dropbox-API-Arg' => json_encode(
                         [
                             'close' => false,
@@ -303,6 +331,7 @@ class ClientTest extends TestCase
             'https://content.dropboxapi.com/2/files/upload_session/append_v2',
             [
                 'headers' => [
+                    'Authorization' => 'Bearer test_token',
                     'Dropbox-API-Arg' => json_encode(
                         [
                             'cursor' => [
@@ -383,6 +412,7 @@ class ClientTest extends TestCase
             'https://content.dropboxapi.com/2/files/upload_session/finish',
             [
                 'headers' => [
+                    'Authorization' => 'Bearer test_token',
                     'Dropbox-API-Arg' => json_encode([
                         'cursor' => [
                             'session_id' => 'mockedUploadSessionId',
@@ -445,7 +475,11 @@ class ClientTest extends TestCase
         $mockGuzzle = $this->mock_guzzle_request(
             json_encode($expectedResponse),
             'https://api.dropboxapi.com/2/users/get_current_account',
-            []
+            [
+                'headers' => [
+                    'Authorization' => 'Bearer test_token',
+                ],
+            ]
         );
 
         $client = new Client('test_token', $mockGuzzle);
@@ -459,7 +493,11 @@ class ClientTest extends TestCase
         $mockGuzzle = $this->mock_guzzle_request(
             null,
             'https://api.dropboxapi.com/2/auth/token/revoke',
-            []
+            [
+                'headers' => [
+                    'Authorization' => 'Bearer test_token',
+                ],
+            ]
         );
 
         $client = new Client('test_token', $mockGuzzle);
@@ -567,6 +605,9 @@ class ClientTest extends TestCase
             json_encode(['name' => 'math']),
             'https://api.dropboxapi.com/2/sharing/create_shared_link_with_settings',
             [
+                'headers' => [
+                    'Authorization' => 'Bearer test_token',
+                ],
                 'json' => [
                     'path' => '/Homework/math',
                     'settings' => [],
@@ -589,6 +630,9 @@ class ClientTest extends TestCase
             ]),
             'https://api.dropboxapi.com/2/sharing/list_shared_links',
             [
+                'headers' => [
+                    'Authorization' => 'Bearer test_token',
+                ],
                 'json' => [
                     'path' => '/Homework/math',
                     'cursor' => 'mocked_cursor_id',
@@ -622,6 +666,24 @@ class ClientTest extends TestCase
         $this->assertEquals($normalizeFunction->invokeArgs($client, ['id:1234567890']), 'id:1234567890');
         $this->assertEquals($normalizeFunction->invokeArgs($client, ['ns:1234567890']), 'ns:1234567890');
         $this->assertEquals($normalizeFunction->invokeArgs($client, ['rev:1234567890']), 'rev:1234567890');
+    }
+
+    /** @test */
+    public function it_can_get_the_access_token()
+    {
+        $client = new Client('test_token');
+
+        $this->assertEquals('test_token', $client->getAccessToken());
+    }
+
+    /** @test */
+    public function it_can_set_the_access_token()
+    {
+        $client = new Client('test_token');
+
+        $client->setAccessToken('another_test_token');
+
+        $this->assertEquals('another_test_token', $client->getAccessToken());
     }
 
     private function mock_guzzle_request($expectedResponse, $expectedEndpoint, $expectedParams)


### PR DESCRIPTION
Currently the access token is set in the constructor only, and when a Guzzle client is passed as a second parameter, the access token is being ignored.

Having a setter allows the user to change accounts dynamically and the getter allows us to test that the client has the right access token.

I am using `spatie/flysystem-dropbox` to create a Dropbox filesystem driver in a Laravel application which manages multiple dropbox accounts.

In my service provider I'm creating the dropbox driver like this, and the `filesystems.disks.dropbox.authorizationToken` config is set dynamically in another part of the application:
```php
Storage::extend('dropbox', function ($app, $config) {
    $client = new \Spatie\Dropbox\Client(
        $config['authorizationToken']
    );

    return new \Leage\Flysystem\Filesystem(
        new \Spatie\FlysystemDropbox\DropboxAdapter($client)
    );
});
```

While that works as expected, I find it hard to test that the dropbox client has the expected access token. In PHPUnit I have to use the **deprecated** `assertAttributeEquals()` assertion or rely on reflection to get the `protected` access token. And even with this, I cannot ensure that the Guzzle client has the correct header.

```php
$client = Storage::disk('dropbox')->getAdapter()->getClient();
$this->assertAttributeEquals('test_token', 'accessToken', $client);
````

Tests should not rely on implementation details, but while I have integration tests for the Dropbox disk, in my unit test I don't want to use a real access token or make a real request to the Dropbox API.

So the getter would be nice:
```php
$client = Storage::disk('dropbox')->getAdapter()->getClient();
$this->assertEquals('test_token', $client->getAccessToken());
```

And the setter would be convenient to change dropbox accounts dynamically in my application, instead of directly setting the config value early, since the FilesystemManager is a singleton.