### PR TITLE
Fix createSharedLinkWithSettings endpoint with empty settings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `dropbox-api` will be documented in this file
 
+## 1.7.1 - 2019-02-13
+
+- fix for `createSharedLinkWithSettings` with empty settings
+
 ## 1.7.0 - 2019-02-06
 
 - add getter and setter for the access token

--- a/src/Client.php
+++ b/src/Client.php
@@ -104,9 +104,12 @@ class Client
     public function createSharedLinkWithSettings(string $path, array $settings = [])
     {
         $parameters = [
-            'path' => $this->normalizePath($path),
-            'settings' => $settings,
+            'path' => $this->normalizePath($path)
         ];
+
+        if (count($settings)) {
+            $parameters = array_merge(compact('settings'), $parameters);
+        }
 
         return $this->rpcEndpointRequest('sharing/create_shared_link_with_settings', $parameters);
     }

--- a/src/Client.php
+++ b/src/Client.php
@@ -104,7 +104,7 @@ class Client
     public function createSharedLinkWithSettings(string $path, array $settings = [])
     {
         $parameters = [
-            'path' => $this->normalizePath($path)
+            'path' => $this->normalizePath($path),
         ];
 
         if (count($settings)) {

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -610,7 +610,6 @@ class ClientTest extends TestCase
                 ],
                 'json' => [
                     'path' => '/Homework/math',
-                    'settings' => [],
                 ],
             ]
         );

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -620,6 +620,34 @@ class ClientTest extends TestCase
     }
 
     /** @test */
+    public function it_can_create_a_shared_link_with_custom_settings()
+    {
+        $mockGuzzle = $this->mock_guzzle_request(
+            json_encode(['name' => 'math']),
+            'https://api.dropboxapi.com/2/sharing/create_shared_link_with_settings',
+            [
+                'headers' => [
+                    'Authorization' => 'Bearer test_token',
+                ],
+                'json' => [
+                    'path' => '/Homework/math',
+                    'settings' => [
+                        'requested_visibility' => 'public',
+                    ],
+                ],
+            ]
+        );
+
+        $client = new Client('test_token', $mockGuzzle);
+
+        $settings = [
+            'requested_visibility' => 'public',
+        ];
+
+        $this->assertEquals(['name' => 'math'], $client->createSharedLinkWithSettings('Homework/math', $settings));
+    }
+
+    /** @test */
     public function it_can_list_shared_links()
     {
         $mockGuzzle = $this->mock_guzzle_request(


### PR DESCRIPTION
Hi, 

This PR hopefully fixes [40](https://github.com/spatie/dropbox-api/issues/40). 

This is my first PR for a Spatie package. So, let me know if there's anything else needed from my side :) 