### PR TITLE
Add getEndpointUrl method

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,14 @@ Here's an example:
 $client->rpcEndpointRequest('search', ['path' => '', 'query' => 'bat cave']);
 ```
 
+If you need to change the subdomain of the endpoint URL that used in the API request, you can prefix the endpoint path with `subdomain::`.
+
+Here's an example:
+
+```php
+$client->rpcEndpointRequest('content::files/get_thumbnail_batch', $parameters);
+```
+
 ## Changelog
 
 Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recently.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Here's an example:
 $client->rpcEndpointRequest('search', ['path' => '', 'query' => 'bat cave']);
 ```
 
-If you need to change the subdomain of the endpoint URL that used in the API request, you can prefix the endpoint path with `subdomain::`.
+If you need to change the subdomain of the endpoint URL used in the API request, you can prefix the endpoint path with `subdomain::`.
 
 Here's an example:
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -539,8 +539,8 @@ class Client
 
     protected function getEndpointUrl(string $subdomain, string $endpoint): string
     {
-        if (count($list = explode('::', $endpoint)) === 2) {
-            list($subdomain, $endpoint) = $list;
+        if (count($parts = explode('::', $endpoint)) === 2) {
+            [$subdomain, $endpoint] = $parts;
         }
 
         return "https://{$subdomain}.dropboxapi.com/2/{$endpoint}";

--- a/src/Client.php
+++ b/src/Client.php
@@ -537,6 +537,15 @@ class Client
         return ($path === '') ? '' : '/'.$path;
     }
 
+    protected function getEndpointUrl(string $subdomain, string $endpoint): string
+    {
+        if (count($list = explode('::', $endpoint)) === 2) {
+            list($subdomain, $endpoint) = $list;
+        }
+
+        return "https://{$subdomain}.dropboxapi.com/2/{$endpoint}";
+    }
+
     /**
      * @param string $endpoint
      * @param array $arguments
@@ -555,7 +564,7 @@ class Client
         }
 
         try {
-            $response = $this->client->post("https://content.dropboxapi.com/2/{$endpoint}", [
+            $response = $this->client->post($this->getEndpointUrl('content', $endpoint), [
                 'headers' => $this->getHeaders($headers),
                 'body' => $body,
             ]);
@@ -575,7 +584,7 @@ class Client
                 $options['json'] = $parameters;
             }
 
-            $response = $this->client->post("https://api.dropboxapi.com/2/{$endpoint}", $options);
+            $response = $this->client->post($this->getEndpointUrl('api', $endpoint), $options);
         } catch (ClientException $exception) {
             throw $this->determineException($exception);
         }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -713,6 +713,17 @@ class ClientTest extends TestCase
         $this->assertEquals('another_test_token', $client->getAccessToken());
     }
 
+    /** @test */
+    public function it_can_change_the_endpoint_subdomain()
+    {
+        $client = new Client('test_token');
+
+        $endpointFunction = static::getMethod('getEndpointUrl');
+
+        $this->assertEquals($endpointFunction->invokeArgs($client, ['api', 'files/delete']), 'https://api.dropboxapi.com/2/files/delete');
+        $this->assertEquals($endpointFunction->invokeArgs($client, ['api', 'content::files/get_thumbnail_batch']), 'https://content.dropboxapi.com/2/files/get_thumbnail_batch');
+    }
+
     private function mock_guzzle_request($expectedResponse, $expectedEndpoint, $expectedParams)
     {
         $mockResponse = $this->getMockBuilder(ResponseInterface::class)


### PR DESCRIPTION
This change allows `files/get_thumbnail_batch` and `files/list_folder/longpoll` to use the `rpcEndpointRequest` method.

For example:

```php
$this->rpcEndpointRequest('content::files/get_thumbnail_batch', $parameters);
$this->rpcEndpointRequest('notify::files/list_folder/longpoll', $parameters);
```
