### PR TITLE
Ability to set custom headers added to use Team APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ $client = new Spatie\Dropbox\Client($authorizationToken);
 
 Look in [the source code of `Spatie\Dropbox\Client`](https://github.com/spatie/dropbox-api/blob/master/src/Client.php) to discover the methods you can use.
 
+If you need to use custom headers for various usages such as to use Team APIs or to pass Document root folder, you can set your custom headers with function `setHeaders()`.
+
+Here's an example:
+
+```php
+$client->setHeaders(['Dropbox-Api-Select-User' => 'dbmid:masjdlajsdnasnlajsfdlasjdan', 'Dropbox-Api-Path-Root' => '{".tag": "namespace_id", "namespace_id": "1234567890"}']);
+```
+
 If you do not find your favorite method, you can directly use the `contentEndpointRequest` and `rpcEndpointRequest` functions.
 
 ```php

--- a/src/Client.php
+++ b/src/Client.php
@@ -33,6 +33,9 @@ class Client
     /** @var string */
     protected $accessToken;
 
+    /** @var array */
+    protected $customHeaders;
+
     /** @var \GuzzleHttp\Client */
     protected $client;
 
@@ -51,6 +54,7 @@ class Client
     public function __construct(string $accessToken, GuzzleClient $client = null, int $maxChunkSize = self::MAX_CHUNK_SIZE, int $maxUploadChunkRetries = 0)
     {
         $this->accessToken = $accessToken;
+        $this->customHeaders = [];
 
         $this->client = $client ?? new GuzzleClient(['handler' => GuzzleFactory::handler()]);
 
@@ -665,7 +669,14 @@ class Client
     protected function getHeaders(array $headers = []): array
     {
         return array_merge([
-            'Authorization' => "Bearer {$this->accessToken}",
-        ], $headers);
+            'Authorization' => "Bearer {$this->accessToken}"
+        ], $headers, $this->customHeaders);
+    }
+
+    /**
+     * Set the HTTP headers
+     */
+    public function setHeaders(array $headers = []){
+        $this->customHeaders = $headers;
     }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -669,14 +669,15 @@ class Client
     protected function getHeaders(array $headers = []): array
     {
         return array_merge([
-            'Authorization' => "Bearer {$this->accessToken}"
+            'Authorization' => "Bearer {$this->accessToken}",
         ], $headers, $this->customHeaders);
     }
 
     /**
-     * Set the HTTP headers
+     * Set the HTTP headers.
      */
-    public function setHeaders(array $headers = []){
+    public function setHeaders(array $headers = [])
+    {
         $this->customHeaders = $headers;
     }
 }


### PR DESCRIPTION
We were facing issues to set custom headers for using Team APIs, we have also checked in Issues for solution from where we have found an [open issue from Dec 2019](https://github.com/spatie/dropbox-api/issues/58).  So we have added this thing.