### PR TITLE
Added downloadZip feature

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -192,6 +192,28 @@ class Client
     }
 
     /**
+     * Download a folder from the user's Dropbox, as a zip file.
+     * The folder must be less than 20 GB in size and have fewer than 10,000 total files.
+     * The input cannot be a single file. Any single file must be less than 4GB in size.
+     *
+     * @param string $path
+     *
+     * @return resource
+     *
+     * @link https://www.dropbox.com/developers/documentation/http/documentation#files-download_zip
+     */
+    public function downloadZip(string $path)
+    {
+        $arguments = [
+            'path' => $this->normalizePath($path),
+        ];
+
+        $response = $this->contentEndpointRequest('files/download_zip', $arguments);
+
+        return StreamWrapper::getResource($response->getBody());
+    }
+
+    /**
      * Returns the metadata for a file or folder.
      *
      * Note: Metadata for the root folder is unsupported.

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -168,6 +168,32 @@ class ClientTest extends TestCase
     }
 
     /** @test */
+    public function it_can_download_a_folder_as_zip()
+    {
+        $expectedResponse = $this->getMockBuilder(StreamInterface::class)
+            ->getMock();
+        $expectedResponse->expects($this->once())
+            ->method('isReadable')
+            ->willReturn(true);
+
+        $mockGuzzle = $this->mock_guzzle_request(
+            $expectedResponse,
+            'https://content.dropboxapi.com/2/files/download_zip',
+            [
+                'headers' => [
+                    'Authorization' => 'Bearer test_token',
+                    'Dropbox-API-Arg' => json_encode(['path' => '/Homework/math']),
+                ],
+                'body' => '',
+            ]
+        );
+
+        $client = new Client('test_token', $mockGuzzle);
+
+        $this->assertTrue(is_resource($client->downloadZip('Homework/math')));
+    }
+
+    /** @test */
     public function it_can_retrieve_metadata()
     {
         $mockGuzzle = $this->mock_guzzle_request(


### PR DESCRIPTION
Dropbox allows download folders as zip: https://www.dropbox.com/developers/documentation/http/documentation#files-download_zip

Example:

```php
$resource = $client->downloadZip($path);
$contents = stream_get_contents($resource);

fclose($resource);
unset($resource);

file_put_contents(basename($path).'.zip', $contents);
```
