### PR TITLE
RFC: Require ClientInterface and add a TokenProvider interface for accesstokens

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -5,6 +5,7 @@ namespace Spatie\Dropbox;
 use Exception;
 use GrahamCampbell\GuzzleFactory\GuzzleFactory;
 use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7;
@@ -58,7 +59,7 @@ class Client
      * @param int $maxUploadChunkRetries How many times to retry an upload session start or append after RequestException.
      * @param string $teamMemberID The team member ID to be specified for Dropbox business accounts
      */
-    public function __construct($accessTokenOrAppCredentials = null, GuzzleClient $client = null, int $maxChunkSize = self::MAX_CHUNK_SIZE, int $maxUploadChunkRetries = 0, string $teamMemberId = null)
+    public function __construct($accessTokenOrAppCredentials = null, ClientInterface $client = null, int $maxChunkSize = self::MAX_CHUNK_SIZE, int $maxUploadChunkRetries = 0, string $teamMemberId = null)
     {
         if (is_array($accessTokenOrAppCredentials)) {
             [$this->appKey, $this->appSecret] = $accessTokenOrAppCredentials;

--- a/src/InMemoryTokenProvider.php
+++ b/src/InMemoryTokenProvider.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Spatie\Dropbox;
-
 
 class InMemoryTokenProvider implements TokenProvider
 {

--- a/src/InMemoryTokenProvider.php
+++ b/src/InMemoryTokenProvider.php
@@ -1,0 +1,23 @@
+<?php
+
+
+namespace Spatie\Dropbox;
+
+
+class InMemoryTokenProvider implements TokenProvider
+{
+    /**
+     * @var string
+     */
+    private $token;
+
+    public function __construct(string $token)
+    {
+        $this->token = $token;
+    }
+
+    public function getToken(): string
+    {
+        return $this->token;
+    }
+}

--- a/src/TokenProvider.php
+++ b/src/TokenProvider.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace Spatie\Dropbox;
+
+
+interface TokenProvider
+{
+    public function getToken(): string;
+}

--- a/src/TokenProvider.php
+++ b/src/TokenProvider.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Spatie\Dropbox;
-
 
 interface TokenProvider
 {


### PR DESCRIPTION
- Require Guzzle ClientInterface instead of GuzzleClient implementation.
- Add TokenProvider interface and move accesstoken as string into simple InMemoryTokenProvider implementation.
- Next to accesstoken as string (or credentials), ability to use a TokenProvider.

In the most simple form, the user can create an adapter that 
implements the `TokenProvider->getToken(): string`,
which internally can take care of token expiration and refreshing the token, 

```php
$tokenProvider = new AutoRefreshingDropBoxTokenService($refreshToken);
$dropbox = new Spatie\Dropbox\Client($tokenProvider);
```
see: #75
