### PR TITLE
Add autoRename parameter for move() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,32 @@ $client = new Spatie\Dropbox\Client();
 
 Look in [the source code of `Spatie\Dropbox\Client`](https://github.com/spatie/dropbox-api/blob/master/src/Client.php) to discover the methods you can use.
 
+Here's an example:
+
+```php
+$content = 'hello, world';
+$client->upload('/dropboxpath/filename.txt', $content, $mode='add');
+
+$from = '/dropboxpath/somefile.txt';
+$to = '/dropboxpath/archive/somefile.txt';
+$client->move($from, $to);
+```
+
+If the destination filename already exists, dropbox will throw an Exception with 'to/conflict/file/..'
+
+The ``upload()`` and ``move()`` methods have an optional extra 'autorename' argument 
+to try and let dropbox automatically rename the file if there is such a conflict.
+
+Here's an example:
+
+```php
+$from = '/dropboxpath/somefile.txt';
+$to = '/dropboxpath/archive/somefile.txt';
+$client->move($from, $to, $autorename=true);
+// with autorename results in 'somefile (1).txt'
+```
+
+
 If you do not find your favorite method, you can directly use the `contentEndpointRequest` and `rpcEndpointRequest` functions.
 
 ```php

--- a/src/Client.php
+++ b/src/Client.php
@@ -336,11 +336,12 @@ class Client
      *
      * @link https://www.dropbox.com/developers/documentation/http/documentation#files-move_v2
      */
-    public function move(string $fromPath, string $toPath): array
+    public function move(string $fromPath, string $toPath, bool $autorename = false): array
     {
         $parameters = [
             'from_path' => $this->normalizePath($fromPath),
             'to_path' => $this->normalizePath($toPath),
+            'autorename' => $autorename,
         ];
 
         return $this->rpcEndpointRequest('files/move_v2', $parameters);

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -350,13 +350,14 @@ class ClientTest extends TestCase
                 'json' => [
                     'from_path' => '/from/path/file.txt',
                     'to_path' => '',
+                    'autorename' => false
                 ],
             ]
         );
 
         $client = new Client('test_token', $mockGuzzle);
 
-        $this->assertEquals($expectedResponse, $client->move('/from/path/file.txt', ''));
+        $this->assertEquals($expectedResponse, $client->move('/from/path/file.txt', '', false));
     }
 
     /** @test */

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -350,7 +350,7 @@ class ClientTest extends TestCase
                 'json' => [
                     'from_path' => '/from/path/file.txt',
                     'to_path' => '',
-                    'autorename' => false
+                    'autorename' => false,
                 ],
             ]
         );


### PR DESCRIPTION
Add a parameter to autorename 'filename' when destination 'filename' already exists.
Otherwise it wil throw an exception like 'to/conflict/file/..'
