### PR TITLE
Fix compability with guzzlehttp/psr7 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,5 +47,8 @@
     },
     "config": {
         "sort-packages": true
+    },
+    "conflict": {
+        "guzzlehttp/psr7": "<1.7.0"
     }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -673,7 +673,7 @@ class Client
     /**
      * @param $contents
      *
-     * @return \GuzzleHttp\Psr7\PumpStream|\GuzzleHttp\Psr7\Stream
+     * @return \GuzzleHttp\Psr7\PumpStream|\GuzzleHttp\Psr7\Stream|StreamInterface
      */
     protected function getStream($contents)
     {
@@ -689,7 +689,7 @@ class Client
             });
         }
 
-        return Psr7\stream_for($contents);
+        return Psr7\Utils::streamFor($contents);
     }
 
     /**


### PR DESCRIPTION
In `guzzlehttp/psr7` v2.0 the function `stream_for` is replaced with `Utils::streamFor`.