### PR TITLE
Added automatic pagination to listSharedLinks

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -166,7 +166,7 @@ class Client
      *
      * @link https://www.dropbox.com/developers/documentation/http/documentation#sharing-list_shared_links
      */
-    public function listSharedLinks(string $path = null, bool $direct_only = false, string $cursor = null): array
+    public function listSharedLinks(string $path = null, bool $direct_only = false, string $cursor = null, array $links = []): array
     {
         $parameters = [
             'path' => $path ? $this->normalizePath($path) : null,
@@ -176,7 +176,15 @@ class Client
 
         $body = $this->rpcEndpointRequest('sharing/list_shared_links', $parameters);
 
-        return $body['links'];
+        if (!empty($body['links'])) {
+            $links = array_merge($links, $body['links']);
+        }
+
+        if (!empty($body['cursor'])) {
+            return $this->listSharedLinks($path, $direct_only, $body['cursor'], $links);
+        }
+
+        return $links;
     }
 
     /**

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -766,7 +766,7 @@ class ClientTest extends TestCase
 
         $this->assertEquals(
             ['url' => 'https://dl.dropboxusercontent.com/apitl/1/YXNkZmFzZGcyMzQyMzI0NjU2NDU2NDU2'],
-            $client->listSharedLinks('Homework/math', true, 'mocked_cursor_id')
+            $client->listSharedLinks('Homework/math', true, 'mocked_cursor_id', [])
         );
     }
 


### PR DESCRIPTION
`listSharedLinks` method does not currently return a cursor.
To prevent breaking backwards compatibility function recursively retrieves more shared links if cursor is present.
This functionality is different to `listFolderContinue` as the same path is being reused.
I have no idea as to how to add a test for this. Sorry.