### PR TITLE
Add refreshable token provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `dropbox-api` will be documented in this file
 
+## Unreleased
+
+- Added refreshable token provider interface.
+
 ## 1.19.1 - 2021-07-04
 
 - fix compability with guzzlehttp/psr7 2.0 (#91)

--- a/src/Client.php
+++ b/src/Client.php
@@ -642,7 +642,7 @@ class Client
         return $response;
     }
 
-    public function rpcEndpointRequest(string $endpoint, array $parameters = null): array
+    public function rpcEndpointRequest(string $endpoint, array $parameters = null, bool $is_refreshed = false): array
     {
         try {
             $options = ['headers' => $this->getHeaders()];
@@ -653,12 +653,18 @@ class Client
 
             $response = $this->client->post($this->getEndpointUrl('api', $endpoint), $options);
         } catch (ClientException $exception) {
-            throw $this->determineException($exception);
+            if (
+                $is_refreshed
+                || !$this->tokenProvider instanceof RefreshableTokenProvider
+                || !$this->tokenProvider->refresh($exception)
+            ) {
+                throw $this->determineException($exception);
+            }
+
+            $response = $this->rpcEndpointRequest($endpoint, $parameters, true);
         }
 
-        $response = json_decode($response->getBody(), true);
-
-        return $response ?? [];
+        return json_decode($response->getBody(), true) ?? [];
     }
 
     protected function determineException(ClientException $exception): Exception

--- a/src/RefreshableTokenProvider.php
+++ b/src/RefreshableTokenProvider.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\Dropbox;
+
+use GuzzleHttp\Exception\ClientException;
+
+interface RefreshableTokenProvider extends TokenProvider
+{
+    /**
+     * @return bool Whether the token was refreshed.
+     */
+    public function refresh(ClientException $exception): bool;
+}


### PR DESCRIPTION
The docs currently reference a fictive `AutoRefreshingDropBoxTokenService` token provider that should be able to automatically refresh the access token through a refresh token. The problem I see is with the "auto" part. Currently, the token provider only provides a token. There is no callback when the request failed; so there is nothing to do, but to examine the exception, see if we can refresh our token, and try the entire request again.

This PR adds the ability to refresh the token "automatically" once. 

It introduces a `RefreshableTokenProvider`. An interface that extends the `TokenProvider` interface, and adds a `::refresh(ClientException $exception): bool` method. 

The `Client` checks the current TokenProvider once, to see if it is refreshable. If it is, it will call `refresh()`, and when this functions returns `true`, it will try the last request once more. After that it fails. 

We can now use this interface to create a custom TokenProvider, which can refresh the access token with the help of a refresh_token.  The `refresh()` method receives the `ClientException` to check if it needs to refresh, or just return `false` if it knows it's unrecoverable.

This way we can Isolate the entire refresh strategy to one (custom) class, and apply it on every request if necessary.


## Example of implementation

```php
use Spatie\Dropbox\RefreshableTokenProvider;
use GuzzleHttp\Exception\ClientException;

class AutoRefreshingDropBoxTokenService implements RefreshableTokenProvider {

    public function __construct(public string $access_token, public string $refresh_token)
    {
    }

    public function getToken(): string
    {
        return $this->access_token;
    }

    public function refresh(ClientException $exception): bool
    {
        if (!$this->isRecoverableException($exception)) {
            return false;
        }

        $this->refreshAccessToken(); // stores new access token.

        return true; // Token is refreshed.
    }

    //...
}

$client = new Client(new AutoRefreshingDropBoxTokenService('access_token','refresh_token'));

```
