### PR TITLE
Fix refreshable token response

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -668,7 +668,7 @@ class Client
                 throw $this->determineException($exception);
             }
 
-            $response = $this->rpcEndpointRequest($endpoint, $parameters, true);
+            return $this->rpcEndpointRequest($endpoint, $parameters, true);
         }
 
         return json_decode($response->getBody(), true) ?? [];

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -772,6 +772,61 @@ class ClientTest extends TestCase
         $client->rpcEndpointRequest('testing/endpoint');
     }
 
+	/** @test */
+	public function rpc_endpoint_request_can_be_retried_with_success()
+	{
+		$errorBody = [
+			'error' => [
+				'.tag' => 'expired_access_token',
+			],
+			'error_summary' => 'expired_access_token/',
+		];
+
+		$successBody = [
+			'access_token' => 'new_token',
+		];
+
+		$token_provider = $this->createConfiguredMock(RefreshableTokenProvider::class, [
+			'getToken' => 'test_token',
+		]);
+
+		$errorResponse = $this->createConfiguredMock(ResponseInterface::class, [
+			'getStatusCode' => 409,
+			'getBody' => json_encode($errorBody),
+		]);
+
+		$successResponse = $this->createConfiguredMock(ResponseInterface::class, [
+			'getStatusCode' => 200,
+			'getBody' => json_encode($successBody),
+		]);
+
+		$mockGuzzle = $this->getMockBuilder(GuzzleClient::class)
+			->setMethods(['post'])
+			->getMock();
+
+		$e = new ClientException(
+			'there was an error',
+			$this->getMockBuilder(RequestInterface::class)->getMock(),
+			$errorResponse
+		);
+
+		$mockGuzzle->expects($this->exactly(2))
+			->method('post')
+			->willReturnOnConsecutiveCalls(
+				$this->throwException($e),
+				$successResponse
+			);
+
+		$token_provider->expects($this->once())
+			->method('refresh')
+			->with($e)
+			->willReturn(true);
+
+		$client = new Client($token_provider, $mockGuzzle);
+
+		$this->assertEquals($successBody, $client->rpcEndpointRequest('testing/endpoint'));
+	}
+
     /** @test */
     public function it_can_create_a_shared_link()
     {


### PR DESCRIPTION
`Error : Call to a member function getBody() on array`

`$response` is already an array when `rpcEndpointRequest()` is called  recursively if `refresh()` returns `true` 

