### PR TITLE
uploadSessionStart and uploadSessionFinish can accept resource

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
     ],
     "require": {
         "php": "^7.1|^8.0",
+        "ext-json": "*",
         "graham-campbell/guzzle-factory": "^3.0|^4.0|^5.0",
         "guzzlehttp/guzzle": "^6.2|^7.0"
     },

--- a/src/Client.php
+++ b/src/Client.php
@@ -544,7 +544,7 @@ class Client
      *
      * @link https://www.dropbox.com/developers/documentation/http/documentation#files-upload_session-finish
      *
-     * @param string|StreamInterface $contents
+     * @param string|resource|StreamInterface $contents
      * @param \Spatie\Dropbox\UploadSessionCursor $cursor
      * @param string $path
      * @param string|array $mode

--- a/src/Client.php
+++ b/src/Client.php
@@ -496,7 +496,7 @@ class Client
      *
      * @link https://www.dropbox.com/developers/documentation/http/documentation#files-upload_session-start
      *
-     * @param string|StreamInterface $contents
+     * @param string|resource|StreamInterface $contents
      * @param bool $close
      *
      * @return UploadSessionCursor


### PR DESCRIPTION
The code below works, but phpstan throws an error

```
Parameter #1 $contents of method Spatie\Dropbox\Client::uploadSessionStart() expects Psr\Http\Message\StreamInterface|string, resource given. 
```
Code sample: 
```php
        $file    = fopen($resultPath, 'rb');
        $session = $this->apiClient->uploadSessionStart($file);
// or
        $this->apiClient->uploadSessionFinish($file, $session, '/' . $name);
```

Additionally added `ext-json` required dependency