### PR TITLE
Add ability to set the namespace ID for requests

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -764,7 +764,7 @@ class Client
                     'Dropbox-API-Path-Root' => json_encode([
                         '.tag' => 'namespace_id',
                         'namespace_id' => $this->namespaceId,
-                    ])
+                    ]),
                 ]
             );
         }

--- a/src/Client.php
+++ b/src/Client.php
@@ -40,6 +40,9 @@ class Client
     protected $teamMemberId;
 
     /** @var string */
+    protected $namespaceId;
+
+    /** @var string */
     protected $appKey;
 
     /** @var string */
@@ -724,6 +727,16 @@ class Client
     }
 
     /**
+     * Set the namespace ID.
+     */
+    public function setNamespaceId(string $namespaceId): self
+    {
+        $this->namespaceId = $namespaceId;
+
+        return $this;
+    }
+
+    /**
      * Get the HTTP headers.
      */
     protected function getHeaders(array $headers = []): array
@@ -740,6 +753,18 @@ class Client
                 $auth,
                 [
                     'Dropbox-API-Select-User' => $this->teamMemberId,
+                ]
+            );
+        }
+
+        if ($this->namespaceId) {
+            $headers = array_merge(
+                $headers,
+                [
+                    'Dropbox-API-Path-Root' => json_encode([
+                        '.tag' => 'namespace_id',
+                        'namespace_id' => $this->namespaceId,
+                    ])
                 ]
             );
         }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -943,6 +943,18 @@ class ClientTest extends TestCase
     }
 
     /** @test */
+    public function setting_the_namespace_id_will_add_it_to_the_header()
+    {
+        $client = new Client('namespace_id');
+
+        $expectedNamespaceId = '012345';
+        $client->setNamespaceId($expectedNamespaceId);
+
+        $getHeadersMethod = static::getMethod('getHeaders');
+        $this->assertArrayHasKey('Dropbox-API-Path-Root', $getHeadersMethod->invoke($client));
+    }
+
+    /** @test */
     public function it_can_change_the_endpoint_subdomain()
     {
         $client = new Client('test_token');


### PR DESCRIPTION
This PR adds support for setting the Namespace ID for the Dropbox-API-Path-Root. This will allow users to set the root directory for the request and have all actions performed relative to the namespace ID. [You can read more about Path Root Header Modes here.](https://www.dropbox.com/developers/reference/path-root-header-modes)

We recently had our Dropbox account upgraded use to Team Spaces, and due to this, we now need to set the namespace for each request. I feel that others may have the same need to explicitly set the namespace as well.