### PR TITLE
Allow starting upload sessions with empty content

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -495,7 +495,11 @@ class Client
         $arguments = compact('close');
 
         $response = json_decode(
-            $this->contentEndpointRequest('files/upload_session/start', $arguments, $contents)->getBody(),
+            $this->contentEndpointRequest(
+                'files/upload_session/start',
+                $arguments,
+                ($contents === '') ? null : $contents
+            )->getBody(),
             true
         );
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -370,6 +370,32 @@ it('can start upload session', function () {
         ->and($uploadSessionCursor->offset)->toBe(23);
 });
 
+it('can start upload session with empty content', function () {
+    $mockGuzzle = $this->mockGuzzleRequest(
+        json_encode(['session_id' => 'mockedUploadSessionId']),
+        'https://content.dropboxapi.com/2/files/upload_session/start',
+        [
+            'headers' => [
+                'Authorization' => 'Bearer test_token',
+                'Dropbox-API-Arg' => json_encode(
+                    [
+                        'close' => false,
+                    ]
+                ),
+                'Content-Type' => 'application/octet-stream',
+            ],
+            'body' => null,
+        ],
+    );
+
+    $client = new Client('test_token', $mockGuzzle);
+    $uploadSessionCursor = $client->uploadSessionStart('');
+
+    expect($uploadSessionCursor)->toBeInstanceOf(UploadSessionCursor::class)
+        ->and($uploadSessionCursor->session_id)->toBe('mockedUploadSessionId')
+        ->and($uploadSessionCursor->offset)->toBe(0);
+});
+
 it('can append to upload session', function () {
     $mockGuzzle = $this->mockGuzzleRequest(
         null,


### PR DESCRIPTION
Fixes `uploadSessionStart('')` so starting an upload session with empty content sends the request as an octet-stream upload.

### Why

Dropbox allows `files/upload_session/start` to be called with an empty body. `uploadSessionFinish` already supports this behavior by allowing empty content, but `uploadSessionStart` did not, which made the two upload-session methods inconsistent.